### PR TITLE
Make install script POSIX compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ more flexibility.
 ## Installation
 
 ```sh
-sh -c "$(curl -sSL https://github.com/soywod/himalaya/raw/master/install.sh)"
+curl -sSL https://raw.githubusercontent.com/soywod/himalaya/master/install.sh | sh
 ```
 
 *See the [wiki section](https://github.com/soywod/himalaya/wiki/Installation)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ more flexibility.
 
 ## Installation
 
-```bash
-curl -sSL https://raw.githubusercontent.com/soywod/himalaya/master/install.sh | bash
+```sh
+sh -c "$(curl -sSL https://github.com/soywod/himalaya/raw/master/install.sh)"
 ```
 
 *See the [wiki section](https://github.com/soywod/himalaya/wiki/Installation)

--- a/install.sh
+++ b/install.sh
@@ -4,61 +4,36 @@ set -eu
 
 DESTDIR="${DESTDIR:-/}"
 PREFIX="${PREFIX:-"$DESTDIR/usr/local"}"
+RELEASES_URL="https://github.com/soywod/himalaya/releases"
 
-releases_url="https://github.com/soywod/himalaya/releases"
+system=$(uname -s | tr [:upper:] [:lower:])
 
-uname_os() {
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case $system in
+  msys*|mingw*|cygwin*|win*) system=windows;;
+  linux|freebsd) system=linux;;
+  darwin) system=macos;;
+  *) echo "Error: Unsupported system: $system"; exit 1;;
+esac
 
-  case $os in
-    msys*) os="windows" ;;
-    mingw*) os="windows" ;;
-    cygwin*) os="windows" ;;
-    win*) os="windows" ;;
-  esac
+if ! tmpdir=$(mktemp -d); then
+  echo "Error: Failed to create tmpdir"
+  exit 1
+else
+  trap "rm -rf $tmpdir" EXIT
+fi
 
-  echo "$os"
-}
+echo "Downloading latest $system release…"
+curl -sLo "$tmpdir/himalaya.tar.gz" "$RELEASES_URL/latest/download/himalaya-$system.tar.gz"
 
-get_system() {
-  case $(uname_os) in
-    linux | freebsd) system="linux" ;;
-    darwin) system="macos" ;;
-    windows) system="windows" ;;
-  esac
+echo "Installing binary…"
+tar -xzf "$tmpdir/himalaya.tar.gz" -C "$tmpdir"
 
-  echo "$system"
-}
+if [ -w "$PREFIX" ]; then
+  mkdir -p "$PREFIX/bin"
+  cp -f -- "$tmpdir/himalaya.exe" "$PREFIX/bin/himalaya"
+else
+  sudo mkdir -p "$PREFIX/bin"
+  sudo cp -f -- "$tmpdir/himalaya.exe" "$PREFIX/bin/himalaya"
+fi
 
-start() {
-  system=$(get_system)
-  if [ -z "$system" ]; then
-    echo "Error: Unsupported system: $system"
-    exit 1
-  fi
-
-  if ! tmpdir=$(mktemp -d); then
-    echo "Error: Failed to create tmpdir"
-    exit 1
-  else
-    trap 'rm -rf $tmpdir' EXIT
-  fi
-
-  echo "Downloading latest $system release…"
-  curl -sLo "$tmpdir/himalaya.tar.gz" "$releases_url/latest/download/himalaya-$system.tar.gz"
-
-  echo "Installing binary…"
-  tar -xzf "$tmpdir/himalaya.tar.gz" -C "$tmpdir"
-
-  if [ -w "$PREFIX" ]; then
-    mkdir -p "$PREFIX/bin"
-    install "$tmpdir/himalaya.exe" "$PREFIX/bin/himalaya"
-  else
-    sudo mkdir -p "$PREFIX/bin"
-    sudo install "$tmpdir/himalaya.exe" "$PREFIX/bin/himalaya"
-  fi
-
-  echo "$("$PREFIX/bin/himalaya" --version) installed!"
-}
-
-start
+echo "$("$PREFIX/bin/himalaya" --version) installed!"


### PR DESCRIPTION
Apart from being POSIX compliant this supports configuring install location through standard `PREFIX` environment variable, for example:
```sh
PREFIX="$HOME/.local" sh -c "$(curl -fsSL https://github.com/soywod/himalaya/raw/master/install.sh)"
```