### PR TITLE
Look for fzf instead of fzf.vim

### DIFF
--- a/vim/autoload/himalaya/mbox.vim
+++ b/vim/autoload/himalaya/mbox.vim
@@ -27,7 +27,7 @@ endfunction
 function! himalaya#mbox#input()
   try
     let mboxes = map(s:cli("mailboxes", [], "Fetching mailboxes"), "v:val.name")
-    if &rtp =~ "fzf.vim"
+    if &rtp =~ "fzf"
       call fzf#run({
         \"source": mboxes,
         \"sink": function("himalaya#mbox#post_input"),


### PR DESCRIPTION
Since `fzf` is what is required and not necessarily `fzf.vim` it would be better to just check for this in the `rtp`.