### PR TITLE
Make install.sh more robust and portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ more flexibility.
 ## Installation
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/soywod/himalaya/master/install.sh | bash
+curl -sSLo install.sh \
+  https://raw.githubusercontent.com/soywod/himalaya/master/install.sh
+less install.sh  # Optionally audit before executing.
+sudo sh install.sh
 ```
 
 *See the [wiki section](https://github.com/soywod/himalaya/wiki/Installation)

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 
-case $OSTYPE in
-    linux-gnu|freebsd*) OS=linux ;;
-    darwin*) OS=macos ;;
-    cygwin|msys|win32) OS=windows ;;
+REPO=https://github.com/soywod/himalaya
+
+die() {
+    printf '%s: %s\n' "${0##*/}" "$1" >&2
+    exit "${2-1}"
+}
+
+set -e
+
+case $(uname -s | tr [:upper:] [:lower:]) in
+    *bsd*|linux*) os=linux ;;
+    darwin*) os=macos ;;
+    cygwin*|mingw*) os=windows ;;
+    *) die 'Unable to detect host operating system.' ;;
 esac
 
-cd /tmp
-echo "Downloading latest ${OS} release…"
-curl -sLo himalaya.tar.gz "https://github.com/soywod/himalaya/releases/latest/download/himalaya-${OS}.tar.gz"
-echo "Installing binary…"
-tar -xzf himalaya.tar.gz
-rm himalaya.tar.gz
-chmod u+x himalaya.exe
-sudo mv himalaya.exe /usr/local/bin/himalaya
+printf 'Downloading latest %s release…\n' "$os" >&2
+trap "rm -f \"$himalaya.tar.gz\" himalaya.exe" EXIT
+curl -sSLo "$himalaya.tar.gz" \
+    "$REPO/releases/latest/download/himalaya-$os.tar.gz"
 
-echo "$(himalaya --version) installed!"
+printf 'Installing binary…\n' >&2
+tar -zx himalaya.exe -f "$himalaya.tar.gz"
+mkdir -p /usr/local/bin
+cp -f himalaya.exe /usr/local/bin/himalaya
+chmod a+rx /usr/local/bin/himalaya
+
+die "$(himalaya --version) installed!" 0

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,10 @@
 #!/bin/bash
 
-get_os () {
-  if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    echo "linux"
-  elif [[ "$OSTYPE" == "freebsd"* ]]; then
-    echo "linux"
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "macos"
-  elif [[ "$OSTYPE" == "cygwin" ]]; then
-    echo "windows"
-  elif [[ "$OSTYPE" == "msys" ]]; then
-    echo "windows"
-  elif [[ "$OSTYPE" == "win32" ]]; then
-    echo "windows"
-  else
-    return -1
-  fi
-}
-
-OS=`get_os`
+case $OSTYPE in
+    linux-gnu|freebsd*) OS=linux ;;
+    darwin*) OS=macos ;;
+    cygwin|msys|win32) OS=windows ;;
+esac
 
 cd /tmp
 echo "Downloading latest ${OS} release…"

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ set -e
 case $(uname -s | tr [:upper:] [:lower:]) in
     *bsd*|linux*) os=linux ;;
     darwin*) os=macos ;;
-    cygwin*|mingw*) os=windows ;;
+    cygwin*|mingw*|win*) os=windows ;;
     *) die 'Unable to detect host operating system.' ;;
 esac
 


### PR DESCRIPTION
With these changes, Bash is no longer required to run the installer—any POSIX compliant shell will do.

Seems like shells other than Bash don't necessarily provide `$OSTYPE` and so the OS detection logic has been adapted to use uname(1) instead.  Ideally needs testing on Windows, macos and supported BSDs before being merged.