### PR TITLE
Match versions in Cargo lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "himalaya"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "env_logger",


### PR DESCRIPTION
This needs to match Cargo.toml to prevent --frozen builds from failing. Can be tested by running `cargo build -j 12 --target x86_64-unknown-linux-gnu --frozen --release` on the master branch where it'll fail and on this branch where it will not.

Should I also update the deployment workflow to use `--frozen` to prevent this in the future? Without an up-to-date lockfile I cannot build this package within NixOS so updating becomes a bit of a hassle :grimacing:
