### PR TITLE
allow insecure TLS option

### DIFF
--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -25,12 +25,14 @@ pub struct Account {
     pub imap_host: String,
     pub imap_port: u16,
     pub imap_starttls: Option<bool>,
+    pub imap_insecure: Option<bool>,
     pub imap_login: String,
     pub imap_passwd_cmd: String,
 
     pub smtp_host: String,
     pub smtp_port: u16,
     pub smtp_starttls: Option<bool>,
+    pub smtp_insecure: Option<bool>,
     pub smtp_login: String,
     pub smtp_passwd_cmd: String,
 }
@@ -54,6 +56,13 @@ impl Account {
         }
     }
 
+    pub fn imap_insecure(&self) -> bool {
+        match self.imap_insecure {
+            Some(true) => true,
+            _ => false,
+        }
+    }
+
     pub fn smtp_creds(&self) -> Result<SmtpCredentials> {
         let passwd = run_cmd(&self.smtp_passwd_cmd).chain_err(|| "Cannot run SMTP passwd cmd")?;
         let passwd = passwd.trim_end_matches("\n").to_owned();
@@ -63,6 +72,13 @@ impl Account {
 
     pub fn smtp_starttls(&self) -> bool {
         match self.smtp_starttls {
+            Some(true) => true,
+            _ => false,
+        }
+    }
+
+    pub fn smtp_insecure(&self) -> bool {
+        match self.smtp_insecure {
             Some(true) => true,
             _ => false,
         }

--- a/src/imap/model.rs
+++ b/src/imap/model.rs
@@ -24,7 +24,12 @@ pub struct ImapConnector<'a> {
 
 impl<'ic> ImapConnector<'ic> {
     pub fn new(account: &'ic Account) -> Result<Self> {
-        let tls = TlsConnector::new().chain_err(|| "Cannot create TLS connector")?;
+        let tls = TlsConnector::builder()
+                .danger_accept_invalid_certs(account.imap_insecure())
+                .danger_accept_invalid_hostnames(account.imap_insecure())
+                .build()
+                .chain_err(|| "Cannot create TLS connector")?;
+
         let client = if account.imap_starttls() {
             imap::connect_starttls(account.imap_addr(), &account.imap_host, &tls)
                 .chain_err(|| "Cannot connect using STARTTLS")


### PR DESCRIPTION
This PR allow to use insecure connection for imap and tls via `imap-insecure` and `smtp-insecure` as discussed in #84.
My use case is for testing with [GreenMail](https://greenmail-mail-test.github.io/greenmail/).