### PR TITLE
Added signature separator option plus some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ methods.*
 
 name = "Your full name"
 downloads-dir = "/abs/path/to/downloads"
-signature = "Regards,"
+signature = """
+--
+Regards,
+"""
 
 [gmail]
 default = true

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -19,7 +19,6 @@ pub struct Account {
     pub name: Option<String>,
     pub downloads_dir: Option<PathBuf>,
     pub signature: Option<String>,
-    pub signature_separator: Option<String>,
     pub default_page_size: Option<usize>,
 
     // Specific
@@ -102,7 +101,6 @@ pub struct Config {
     pub downloads_dir: Option<PathBuf>,
     pub notify_cmd: Option<String>,
     pub signature: Option<String>,
-    pub signature_separator: Option<String>,
     pub default_page_size: Option<usize>,
 
     #[serde(flatten)]
@@ -214,14 +212,6 @@ impl Config {
             .signature
             .as_ref()
             .or_else(|| self.signature.as_ref())
-            .map(|sig| sig.to_owned())
-    }
-
-    pub fn signature_separator(&self, account: &Account) -> Option<String> {
-        account
-            .signature_separator
-            .as_ref()
-            .or_else(|| self.signature_separator.as_ref())
             .map(|sig| sig.to_owned())
     }
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -19,6 +19,7 @@ pub struct Account {
     pub name: Option<String>,
     pub downloads_dir: Option<PathBuf>,
     pub signature: Option<String>,
+    pub signature_separator: Option<String>,
     pub default_page_size: Option<usize>,
 
     // Specific
@@ -101,6 +102,7 @@ pub struct Config {
     pub downloads_dir: Option<PathBuf>,
     pub notify_cmd: Option<String>,
     pub signature: Option<String>,
+    pub signature_separator: Option<String>,
     pub default_page_size: Option<usize>,
 
     #[serde(flatten)]
@@ -212,6 +214,14 @@ impl Config {
             .signature
             .as_ref()
             .or_else(|| self.signature.as_ref())
+            .map(|sig| sig.to_owned())
+    }
+
+    pub fn signature_separator(&self, account: &Account) -> Option<String> {
+        account
+            .signature_separator
+            .as_ref()
+            .or_else(|| self.signature_separator.as_ref())
             .map(|sig| sig.to_owned())
     }
 

--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -529,7 +529,6 @@ impl<'m> Msg<'m> {
     fn add_signature(tpl: &mut Vec<String>, config: &Config, account: &Account) {
         if let Some(sig) = config.signature(&account) {
             tpl.push(String::new());
-            tpl.push(config.signature_separator(&account).unwrap_or_else(|| "--".to_string()));
             for line in sig.split("\n") {
                 tpl.push(line.to_string());
             }

--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -521,6 +521,7 @@ impl<'m> Msg<'m> {
 
     fn add_content(tpl: &mut Vec<String>, content: Option<Vec<String>>) {
         if let Some(c) = content {
+            tpl.push(String::new()); // Separator between headers and body
             tpl.extend(c);
         }
     }
@@ -543,7 +544,6 @@ impl<'m> Msg<'m> {
         Msg::add_cc_header(&mut tpl, msg_spec.cc);
         Msg::add_to_header(&mut tpl, msg_spec.to);
         Msg::add_subject_header(&mut tpl, msg_spec.subject);
-        tpl.push(String::new()); // Separator between headers and body
         Msg::add_content(&mut tpl, msg_spec.default_content);
         Msg::add_signature(&mut tpl, config, account);
         Ok(Tpl(tpl.join("\r\n")))


### PR DESCRIPTION
closes #113 

I started adding an option to change the default '--' to separate the content and signature of a message. While doing so I also merge some common code for the `build_xxx` functions.