### PR TITLE
Add .desktop file

### DIFF
--- a/assets/himalaya.desktop
+++ b/assets/himalaya.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Type=Application
+Name=himalaya
+DesktopName=Himalaya
+GenericName=Mail Reader
+Comment=CLI email client written in Rust
+Comment[lo]=CLI ອີເມວໄຄລແອນທີ່ຂຽນດ້ວຍພາສາRust
+Comment[th]=CLI อีเมล์ไคลแอนท์ที่เขียนด้วยภาษาRust
+Terminal=true
+Exec=himalaya %U
+Categories=Application;Network
+Keywords=email
+MimeType=x-scheme-handler/mailto;message/rfc822
+Actions=Compose
+
+[Desktop Action Compose]
+Name=Compose
+Exec=himalaya write %U

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,10 @@
               # configure non-Rust dependencies (see below) here.
               ${name} = oldAttrs: {
                 inherit buildInputs nativeBuildInputs;
+                postInstall = ''
+                  mkdir -p $out/share/applications/
+                  cp assets/himalaya.desktop $out/share/applications/
+                '';
               };
             };
           };


### PR DESCRIPTION
fixes #160

It seems other projects actually just put this in an `assets/` directory. This would probably be the place say a logo would go. 

The flake could maybe be better overriding the `Exec` with the location in the store, but I think this is good enough and it gives package maintainers a good start.

The `Terminal=true` value makes it be launched in the user's configured terminal