### PR TITLE
Add Message-Id header to msg

### DIFF
--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -291,8 +291,11 @@ impl<'m> Msg<'m> {
 
             match h.get_key().to_lowercase().as_str() {
                 "in-reply-to" => msg.in_reply_to(value.parse().unwrap()),
-                "from" => match value.parse() {
-                    Ok(addr) => msg.from(addr),
+                "from" => match value.parse::<lettre::message::Mailbox>() {
+                    Ok(addr) => {
+                        let msg_id = format!("{}@{}", Uuid::new_v4().to_string(), addr.email.domain());
+                        msg.from(addr).message_id(Some(msg_id))
+                    }
                     Err(_) => msg,
                 },
                 "to" => value


### PR DESCRIPTION
Hi! 

I ran into an issue where my emails were being rejected because of a missing Message-Id header.

Since lettre has support for this it was trivial to fix.

Here is a [link](https://github.com/lettre/lettre/blob/0439bab87481dc7ce30c8a79492f14b729df6608/src/message/mod.rs#L357) to lettre's implementation/docs.

~~The default option with None works fine, but it will use the local hostname as the suffix.
Perhaps a better solution would be to use the From header's domain.~~

Message-Id is generated from a uuid and the from address domain.

Happy to make changes as necessary!
