### PR TITLE
disable cursorline for read/write in vim plugin

### DIFF
--- a/vim/ftplugin/himalaya-msg-read.vim
+++ b/vim/ftplugin/himalaya-msg-read.vim
@@ -1,6 +1,5 @@
 setlocal bufhidden=wipe
 setlocal buftype=nofile
-setlocal cursorline
 setlocal filetype=mail
 setlocal foldexpr=himalaya#shared#thread#fold(v:lnum)
 setlocal foldmethod=expr

--- a/vim/ftplugin/himalaya-msg-write.vim
+++ b/vim/ftplugin/himalaya-msg-write.vim
@@ -1,4 +1,3 @@
-setlocal cursorline
 setlocal filetype=mail
 setlocal foldexpr=himalaya#shared#thread#fold(v:lnum)
 setlocal foldmethod=expr


### PR DESCRIPTION
Hello! This PR is more of an opinion thing than a bug fix, but the vim plugin enables the `cursorline` option for the `himalaya-message-list` filetype, as seen below, which makes sense:

![image_2021-08-29-16-23-49](https://user-images.githubusercontent.com/36740602/131264485-dbfbe7cb-9f2f-455d-9a48-0e4ff5ab2469.png)

However, it also does the same thing for both reading and writing messages, which is something that I believe should be left up to the user, as having cursorline enabled in these buffers is really more of an editor preference thing than it is a UI as in the case of the `himalaya-message-list` filetype. Here are the corresponding screenshots:

![image_2021-08-29-16-24-49](https://user-images.githubusercontent.com/36740602/131264540-c6e6d130-074c-404c-91da-5010f7326304.png)
![image_2021-08-29-16-26-41](https://user-images.githubusercontent.com/36740602/131264541-1b41f46a-2813-4f17-8039-44e76f98a6d5.png)

If this PR is merged and someone prefers `cursorline` in their read and write buffers, they can easily set that preference themself by placing the following line in their vim/neovim configuration:

```vim
autocmd FileType mail setlocal cursorline
```