### PR TITLE
Fix the message list bug

### DIFF
--- a/vim/autoload/himalaya/msg.vim
+++ b/vim/autoload/himalaya/msg.vim
@@ -14,8 +14,8 @@ function! s:format_msg_for_list(msg)
   let flag_flagged = index(a:msg.flags, "Flagged") == -1 ? " " : "!"
   let flag_replied = index(a:msg.flags, "Answered") == -1 ? " " : "↵"
   let msg.flags = printf("%s %s %s", flag_new, flag_replied, flag_flagged)
-  let msg.subject = a:msg.headers.subject
-  let msg.sender = a:msg.headers.from[0]
+  let msg.subject = a:msg.subject
+  let msg.sender = a:msg.sender
   let msg.date = a:msg.date
   return msg
 endfunction
@@ -67,11 +67,11 @@ function! himalaya#msg#read()
       \printf("Fetching message %d", s:msg_id),
       \1,
     \)
-    let attachment = len(msg.attachments) > 0 ? " []" : ""
+    let attachment = msg.hasAttachment ? " []" : ""
     execute printf("silent! edit Himalaya read message [%d]%s", s:msg_id, attachment)
     setlocal modifiable
     silent execute "%d"
-    call append(0, split(substitute(msg.body.plain, "\r", "", "g"), "\n"))
+    call append(0, split(substitute(msg.content, "\r", "", "g"), "\n"))
     silent execute "$d"
     setlocal filetype=himalaya-msg-read
     let &modified = 0


### PR DESCRIPTION
With the current version of Himalaya, the Vim front breaks because it
can't find headers.subject in the JSON output from Himalaya. The JSON
output today from Himalaya representing a message looks like so

```json
    {
      "uid": 12345,
      "flags": [],
      "subject": "Subject",
      "subject_len": 7,
      "sender": "Sender",
      "sender_len": 6,
      "date": "2020-12-11 06:38:19"
    },
```

And the JSON for a message is structured like so

```json
{
  "response": {
    "content": "Some email with attachments — strings attached.\r\n",
    "hasAttachment": 1
  }
}
```

This reverts some of the changes in b9a9d0e, but not all of them.

Resolves #208 