### PR TITLE
One Read Pane

### DIFF
--- a/vim/autoload/himalaya/msg.vim
+++ b/vim/autoload/himalaya/msg.vim
@@ -64,6 +64,7 @@ function! himalaya#msg#read()
       \printf("Fetching message %d", s:msg_id),
       \1,
     \)
+    call s:close_open_buffers('Himalaya read message')
     execute printf("silent! botright new Himalaya read message [%d]", s:msg_id)
     setlocal modifiable
     silent execute "%d"
@@ -374,4 +375,12 @@ function! s:get_focused_msg_ids(from, to)
   catch
     throw "messages not found"
   endtry
+endfunction
+
+function! s:close_open_buffers(name)
+  let l:open_buffers = filter(range(1, bufnr('$')), 'bufexists(v:val)')
+  let l:target_buffers = filter(l:open_buffers, 'buffer_name(v:val) =~ a:name')
+  for buffer_to_close in l:target_buffers
+    execute ":bwipeout " . buffer_to_close
+  endfor
 endfunction


### PR DESCRIPTION
0.5.0 came with the amazing option of reading the mail in the same view.
The issue with this is, if you go back to the message list and read some
new mail, it opens a new pane to read the new mail. This change follows
the path of modern mail readers which have one pane to load the email in.

Technically, this change closes any open "Himalaya read message" pane
before creating a new one. This close-open should create the illusion of
having the same pane reload the content.

A possible extension of this would be to clear the contents of the pane,
and re-use the same pane to load the new message. A good time to go this
extension is if Himalaya chooses to use persistent connections to the
mail server.
