### PR TITLE
Fixes 2 separate issues related to #227.

### DIFF
--- a/src/domain/msg/msg_handler.rs
+++ b/src/domain/msg/msg_handler.rs
@@ -212,7 +212,8 @@ pub fn read<'a, OutputService: OutputServiceInterface, ImapService: ImapServiceI
     imap: &mut ImapService,
 ) -> Result<()> {
     let msg = if raw {
-        String::from_utf8(imap.find_raw_msg(&seq)?)?
+        // Emails don't always have valid utf8. Using "lossy" to display what we can.
+        String::from_utf8_lossy(&imap.find_raw_msg(&seq)?).into_owned()
     } else {
         imap.find_msg(&seq)?.fold_text_parts(text_mime)
     };


### PR DESCRIPTION
Reading a message raw uses uses utf_lossy to ensure the message can be read
even if there is invalid utf8. Also an invalid sender address will default to
the empty string.

I'm not sure why the sender needs to be parsed at all when using the "read"
command. Maybe I need to understand why, or maybe it should be removed.