### PR TITLE
Implement contact completion with completefunc

### DIFF
--- a/email-manager/vim/README.md
+++ b/email-manager/vim/README.md
@@ -49,6 +49,24 @@ let g:himalaya_telescope_preview_enabled = 0
 Should enable telescope preview when picking a mailbox with the telescope
 provider.
 
+### Contact completion
+
+```vim
+let g:himalaya_complete_contact_cmd = '<your completion command>'
+```
+
+Define the command to use for contact completion. When this is set,
+`completefunc` will be set when composing messages so that contacts can be
+completed with `<C-x><C-u>`.
+
+The command must print each possible result on its own line. Each line must
+contain tab-separated fields; the first must be the email address, and the
+second, if present, must be the name. `%s` in the command will be replaced
+with the search query.
+
+For example, to complete contacts with khard, you could use
+`khard email --remove-first-line --parsable '%s'` as the completion command.
+
 ## Usage
 
 ### List messages view

--- a/email-manager/vim/autoload/himalaya/msg.vim
+++ b/email-manager/vim/autoload/himalaya/msg.vim
@@ -305,6 +305,37 @@ function! himalaya#msg#attachments()
   endtry
 endfunction
 
+function! himalaya#msg#complete_contact(findstart, base)
+  try
+    if a:findstart
+      if !exists("g:himalaya_complete_contact_cmd")
+        echoerr "You must set 'g:himalaya_complete_contact_cmd' to complete contacts"
+        return -3
+      endif
+
+      " search for everything up to the last colon or comma
+      let line_to_cursor = getline(".")[:col(".") - 1]
+      let start = match(line_to_cursor, '[^:,]*$')
+
+      " don't include leading spaces
+      while start <= len(line_to_cursor) && line_to_cursor[start] == " "
+        let start += 1
+      endwhile
+
+      return start
+    else
+      let output = system(substitute(g:himalaya_complete_contact_cmd, "%s", a:base, ""))
+      let lines = split(output, "\n")
+
+      return map(lines, "s:line_to_complete_item(v:val)")
+    endif
+  catch
+    if !empty(v:exception)
+      redraw | call himalaya#shared#log#err(v:exception)
+    endif
+  endtry
+endfunction
+
 " Utils
 
 " https://newbedev.com/get-usable-window-width-in-vim-script
@@ -352,4 +383,15 @@ function! s:close_open_buffers(name)
   for buffer_to_close in target_buffers
     execute ":bwipeout " . buffer_to_close
   endfor
+endfunction
+
+function! s:line_to_complete_item(line)
+  let fields = split(a:line, "\t")
+  let email = fields[0]
+  let name = ""
+  if len(fields) > 1
+    let name = '"' . fields[1] . '" '
+  endif
+
+  return name . "<" . email . ">"
 endfunction

--- a/email-manager/vim/doc/himalaya.txt
+++ b/email-manager/vim/doc/himalaya.txt
@@ -46,6 +46,23 @@ TELESCOPE PREVIEW
 Should enable telescope preview when picking a mailbox with the telescope
 provider.
 
+------------------------------------------------------------------------------
+CONTACT COMPLETION
+>
+  let g:himalaya_complete_contact_cmd = '<your completion command>'
+<
+Define the command to use for contact completion. When this is set,
+'completefunc' will be set when composing messages so that contacts can be
+completed with |i_CTRL-X_CTRL-U|.
+
+The command must print each possible result on its own line. Each line must
+contain tab-separated fields; the first must be the email address, and the
+second, if present, must be the name. `%s` in the command will be replaced
+with the search query.
+
+For example, to complete contacts with khard, you could use
+`khard email --remove-first-line --parsable '%s'` as the completion command.
+
 ==============================================================================
 USAGE                                                         *himalaya-usage* 
 

--- a/email-manager/vim/ftplugin/himalaya-msg-write.vim
+++ b/email-manager/vim/ftplugin/himalaya-msg-write.vim
@@ -3,6 +3,10 @@ setlocal foldexpr=himalaya#shared#thread#fold(v:lnum)
 setlocal foldmethod=expr
 setlocal startofline
 
+if exists("g:himalaya_complete_contact_cmd")
+  setlocal completefunc=himalaya#msg#complete_contact
+endif
+
 augroup himalaya_write
   autocmd! * <buffer>
   autocmd  BufWriteCmd <buffer> call himalaya#msg#draft_save()


### PR DESCRIPTION
This allows users to define a command for contact completion with
`g:himalaya_complete_contact_cmd` and trigger it with `<C-x><C-u>` when
writing an email.