### PR TITLE
add always a newline for the outputs.

### DIFF
--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -9,7 +9,7 @@ pub trait Print {
 
 impl Print for &str {
     fn print(&self, writter: &mut dyn WriteColor) -> Result<()> {
-        write!(writter, "{}", self).with_context(|| {
+        writeln!(writter, "{}", self).with_context(|| {
             error!(r#"cannot write string to writter: "{}""#, self);
             "cannot write string to writter"
         })


### PR DESCRIPTION
Hi @soywod, this is my second PR because the first one (#248) doesn't allow me to change the source branch from `master` to `development`. In this  PR:

- the target branch is `soywod/development`.
- I use `writeln!` instead of `{}\n`.
- I also tested with zero ZSH configuration. I still see % in the same line, but this PR **will fix** this problem.

![image](https://user-images.githubusercontent.com/72323/139595070-afe84ada-e295-4542-9e5a-bd132fe61f31.png)


Thanks. I'll close #248.