### PR TITLE
Improve attachment output

### DIFF
--- a/src/domain/msg/msg_handler.rs
+++ b/src/domain/msg/msg_handler.rs
@@ -43,6 +43,7 @@ pub fn attachments<'a, Printer: PrinterService, ImapService: ImapServiceInterfac
     for attachment in attachments {
         let filepath = account.downloads_dir.join(&attachment.filename);
         debug!("downloading {}…", attachment.filename);
+        printer.print(format!("downloading {}…", attachment.filename));
         fs::write(&filepath, &attachment.content)
             .context(format!("cannot download attachment {:?}", filepath))?;
     }


### PR DESCRIPTION
Fix #281 

This is a small PR to display the filename of the attachments downloaded. 

However, I have a warning when running `cargo check`:

```rust
warning: unused `Result` that must be used
  --> src/domain/msg/msg_handler.rs:46:9
   |
46 |         printer.print(format!("downloading {}…", attachment.filename));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled

warning: `himalaya` (bin "himalaya") generated 1 warning
```

I understand that Rust uses some structures that auto-handle Success/Error, but I don't get why there is no warning for the same function on line 51. I have found this [SO thread](https://stackoverflow.com/questions/63437768/unused-stdresultresult-that-must-be-used-when-using-writeln) but it feels really redundant with the debug line.

This is my first contact with Rust, but it shouldn't be too hard to fix ^^