### PR TITLE
Fix replies

### DIFF
--- a/src/msg/msg_entity.rs
+++ b/src/msg/msg_entity.rs
@@ -164,11 +164,11 @@ impl Msg {
     pub fn into_reply(mut self, all: bool, account: &AccountConfig) -> Result<Self> {
         let account_addr = account.address()?;
 
-        // Message-Id
-        self.message_id = None;
-
         // In-Reply-To
         self.in_reply_to = self.message_id.to_owned();
+
+        // Message-Id
+        self.message_id = None;
 
         // To
         let addrs = self


### PR DESCRIPTION
When a message is converted to a reply, the `In-Reply-To`-header is set after the message id has already been cleared. This PR reverses the order to fix this issue.