### PR TITLE
renaming the `Print` trait to `Printable`

### DIFF
--- a/cli/src/config/account_handlers.rs
+++ b/cli/src/config/account_handlers.rs
@@ -41,7 +41,7 @@ mod tests {
 
     use crate::{
         config::{DeserializedAccountConfig, DeserializedImapAccountConfig},
-        output::{Print, PrintTable, WriteColor},
+        output::{Printable, PrintTable, WriteColor},
     };
 
     use super::*;
@@ -96,10 +96,10 @@ mod tests {
                 data.print_table(&mut self.writer, opts)?;
                 Ok(())
             }
-            fn print_str<T: Debug + Print>(&mut self, _data: T) -> Result<()> {
+            fn print_str<T: Debug + Printable>(&mut self, _data: T) -> Result<()> {
                 unimplemented!()
             }
-            fn print_struct<T: Debug + Print + serde::Serialize>(
+            fn print_struct<T: Debug + Printable + serde::Serialize>(
                 &mut self,
                 _data: T,
             ) -> Result<()> {

--- a/cli/src/mbox/mbox_handlers.rs
+++ b/cli/src/mbox/mbox_handlers.rs
@@ -39,7 +39,7 @@ mod tests {
         backends::{ImapMbox, ImapMboxAttr, ImapMboxAttrs, ImapMboxes},
         mbox::Mboxes,
         msg::{Envelopes, Msg},
-        output::{Print, PrintTable, WriteColor},
+        output::{Printable, PrintTable, WriteColor},
     };
 
     use super::*;
@@ -94,10 +94,10 @@ mod tests {
                 data.print_table(&mut self.writer, opts)?;
                 Ok(())
             }
-            fn print_str<T: Debug + Print>(&mut self, _data: T) -> Result<()> {
+            fn print_str<T: Debug + Printable>(&mut self, _data: T) -> Result<()> {
                 unimplemented!()
             }
-            fn print_struct<T: Debug + Print + serde::Serialize>(
+            fn print_struct<T: Debug + Printable + serde::Serialize>(
                 &mut self,
                 _data: T,
             ) -> Result<()> {

--- a/cli/src/output/print.rs
+++ b/cli/src/output/print.rs
@@ -2,17 +2,17 @@ use anyhow::{Context, Result};
 
 use crate::output::WriteColor;
 
-pub trait Print {
+pub trait Printable {
     fn print(&self, writer: &mut dyn WriteColor) -> Result<()>;
 }
 
-impl Print for &str {
+impl Printable for &str {
     fn print(&self, writer: &mut dyn WriteColor) -> Result<()> {
         writeln!(writer, "{}", self).context("cannot write string to writer")
     }
 }
 
-impl Print for String {
+impl Printable for String {
     fn print(&self, writer: &mut dyn WriteColor) -> Result<()> {
         self.as_str().print(writer)
     }

--- a/cli/src/output/printer_service.rs
+++ b/cli/src/output/printer_service.rs
@@ -6,11 +6,11 @@ use std::{
 };
 use termcolor::{ColorChoice, StandardStream};
 
-use crate::output::{OutputFmt, OutputJson, Print, PrintTable, PrintTableOpts, WriteColor};
+use crate::output::{OutputFmt, OutputJson, Printable, PrintTable, PrintTableOpts, WriteColor};
 
 pub trait PrinterService {
-    fn print_str<T: Debug + Print>(&mut self, data: T) -> Result<()>;
-    fn print_struct<T: Debug + Print + serde::Serialize>(&mut self, data: T) -> Result<()>;
+    fn print_str<T: Debug + Printable>(&mut self, data: T) -> Result<()>;
+    fn print_struct<T: Debug + Printable + serde::Serialize>(&mut self, data: T) -> Result<()>;
     fn print_table<T: Debug + erased_serde::Serialize + PrintTable + ?Sized>(
         &mut self,
         data: Box<T>,
@@ -25,14 +25,14 @@ pub struct StdoutPrinter {
 }
 
 impl PrinterService for StdoutPrinter {
-    fn print_str<T: Debug + Print>(&mut self, data: T) -> Result<()> {
+    fn print_str<T: Debug + Printable>(&mut self, data: T) -> Result<()> {
         match self.fmt {
             OutputFmt::Plain => data.print(self.writer.as_mut()),
             OutputFmt::Json => Ok(()),
         }
     }
 
-    fn print_struct<T: Debug + Print + serde::Serialize>(&mut self, data: T) -> Result<()> {
+    fn print_struct<T: Debug + Printable + serde::Serialize>(&mut self, data: T) -> Result<()> {
         match self.fmt {
             OutputFmt::Plain => data.print(self.writer.as_mut()),
             OutputFmt::Json => serde_json::to_writer(self.writer.as_mut(), &OutputJson::new(data))

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -12,7 +12,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     config::Format,
-    output::{Print, PrintTableOpts, WriteColor},
+    output::{Printable, PrintTableOpts, WriteColor},
 };
 
 /// Defines the default terminal size.
@@ -126,7 +126,7 @@ impl Cell {
 }
 
 /// Makes the cell printable.
-impl Print for Cell {
+impl Printable for Cell {
     fn print(&self, writer: &mut dyn WriteColor) -> Result<()> {
         // Applies colors to the cell
         writer


### PR DESCRIPTION
Just a little renaming which sounds a little bit better in my opinion.