### PR TITLE
vim: match supported commands to available shortcuts

### DIFF
--- a/vim/plugin/himalaya.vim
+++ b/vim/plugin/himalaya.vim
@@ -10,7 +10,20 @@ endif
 let s:cpo_backup = &cpo
 set cpo&vim
 
-command! -nargs=* Himalaya call himalaya#msg#list(<f-args>)
+command! -nargs=* Himalaya            call himalaya#msg#list(<f-args>)
+command! -nargs=* HimalayaMove        call himalaya#msg#move()
+command! -nargs=* HimalayaCopy        call himalaya#msg#copy()
+command! -nargs=* HimalayaDelete      call himalaya#msg#delete()
+command! -nargs=* HimalayaWrite       call himalaya#msg#write()
+command! -nargs=* HimalayaReply       call himalaya#msg#reply()
+command! -nargs=* HimalayaReplyAll    call himalaya#msg#reply_all()
+command! -nargs=* HimalayaForward     call himalaya#msg#forward()
+command! -nargs=1 HimalayaMbox        call himalaya#mbox#_change(<f-args>)
+command! -nargs=* HimalayaMboxList    call himalaya#mbox#change()
+command! -nargs=* HimalayaNextPage    call himalaya#mbox#next_page()
+command! -nargs=* HimalayaPrevPage    call himalaya#mbox#prev_page()
+command! -nargs=* HimalayaAttach      call himalaya#msg#add_attachment()
+command! -nargs=* HimalayaAttachments call himalaya#msg#attachments()
 
 " Restore cpo
 let &cpo = s:cpo_backup


### PR DESCRIPTION
This expands the list of supported "full name" commands (i.e.
`Himalaya<Action>`) to match the list of available actions supported by
the default keyboard shortcut bindings for Himalaya. This is mostly
preferential, but it's sometimes easier and faster to invoke vim
commands based on the name of the action you're seeking to perform,
rather than trying to remember a specific keyboard binding.

___

Also, thanks for making Himalaya -- I've really been enjoying using it!