### PR TITLE
cli: add option to choose color manually

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use himalaya_lib::{
     account::{Account, BackendConfig, DeserializedConfig, DEFAULT_INBOX_FOLDER},
     backend::Backend,
 };
-use std::{convert::TryFrom, env};
+use std::{convert::TryFrom, env, str::FromStr};
 use url::Url;
 
 use himalaya::{
@@ -11,7 +11,7 @@ use himalaya::{
     config::{account_args, account_handlers, config_args},
     mbox::{mbox_args, mbox_handlers},
     msg::{flag_args, flag_handlers, msg_args, msg_handlers, tpl_args, tpl_handlers},
-    output::{output_args, OutputFmt, StdoutPrinter},
+    output::{output_args, ColorFmt, OutputFmt, StdoutPrinter},
     smtp::LettreService,
 };
 
@@ -119,7 +119,12 @@ fn main() -> Result<()> {
         .value_of("mbox-source")
         .or_else(|| account_config.mailboxes.get("inbox").map(|s| s.as_str()))
         .unwrap_or(DEFAULT_INBOX_FOLDER);
-    let mut printer = StdoutPrinter::try_from(m.value_of("output"))?;
+    let fmt = OutputFmt::try_from(m.value_of("output"))?;
+    let color = ColorFmt::from_str(
+        m.value_of("color")
+            .context("Color option has a default value")?,
+    )?;
+    let mut printer = StdoutPrinter::new(fmt, color);
     #[cfg(feature = "imap-backend")]
     let mut imap;
 

--- a/cli/src/output/output_args.rs
+++ b/cli/src/output/output_args.rs
@@ -22,5 +22,28 @@ pub fn args<'a>() -> Vec<Arg<'a, 'a>> {
             .value_name("LEVEL")
             .possible_values(&["error", "warn", "info", "debug", "trace"])
             .default_value("info"),
+        Arg::with_name("color")
+            .long("color")
+            .help(
+                "
+This flag controls when to use colors. The default setting is 'auto', which
+means himalaya will try to guess when to use colors. For example, if himalaya is
+printing to a terminal, then it will use colors, but if it is redirected to a
+file or a pipe, then it will suppress color output. himalaya will suppress color
+output in some other circumstances as well. For example, if the TERM
+environment variable is not set or set to 'dumb', then himalaya will not use
+colors.
+
+The possible values for this flag are:
+
+never    Colors will never be used.
+auto     The default. himalaya tries to be smart.
+always   Colors will always be used regardless of where output is sent.
+ansi     Like 'always', but emits ANSI escapes (even in a Windows console).
+",
+            )
+            .possible_values(&["never", "auto", "always", "ansi"])
+            .default_value("auto")
+            .value_name("WHEN"),
     ]
 }

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -339,7 +339,7 @@ mod tests {
 
     macro_rules! write_items {
         ($writer:expr, $($item:expr),*) => {
-            Table::print($writer, &[$($item,)*], PrintTableOpts { format: &Format::Auto, max_width: Some(20) }).unwrap();
+            Table::print($writer, &[$($item,)*], PrintTableOpts { format: &TextPlainFormat::Auto, max_width: Some(20) }).unwrap();
         };
     }
 

--- a/lib/tests/test_notmuch_backend.rs
+++ b/lib/tests/test_notmuch_backend.rs
@@ -19,9 +19,9 @@ fn test_notmuch_backend() {
     notmuch::Database::create(mdir.path()).unwrap();
 
     // configure accounts
-    let account_config = AccountConfig {
+    let account_config = Account {
         mailboxes: HashMap::from_iter([("inbox".into(), "*".into())]),
-        ..AccountConfig::default()
+        ..Account::default()
     };
     let mdir_config = MaildirBackendConfig {
         maildir_dir: mdir.path().to_owned(),


### PR DESCRIPTION
I'm currently working on a full integration with `fzf` and himalaya auto-detects `FZF_DEFAULT_COMMAND` and `--preview` as no tty. It would be great if these changes could be merged.