### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,41 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2023-02-14
+
+### Added
+
+- Added command `folders expunge` that deletes all emails marked for
+  deletion.
+  
+### Changed
+
+- Changed the location of the
+  [documentation](https://pimalaya.org/himalaya/docs/).
+
+### Fixed
+
+- Fixed broken links in README.md.
+
+### Removed
+
+- Removed the `maildir-backend` cargo feature, it is now included by
+  default.
+- Removed issues section on GitHub, now issues need to be opened by
+  sending an email at
+  [~soywod/pimalaya@todo.sr.ht](mailto:~soywod/pimalaya@todo.sr.ht).
+
 ## [0.7.0] - 2023-02-08
 
 ### Added
 
-* Added offline support with the `account sync` command to synchronize
+- Added offline support with the `account sync` command to synchronize
   a backend to a local Maildir backend [#342].
-* Added the flag `--disable-cache` to not use the local Maildir
+- Added the flag `--disable-cache` to not use the local Maildir
   backend.
-* Added the email composer (from its own
+- Added the email composer (from its own
   [repository](https://git.sr.ht/~soywod/mime-msg-builder)) [#341].
-* Added Musl builds to releases [#356].
-* Added `himalaya man` command to generate man page [#419].
+- Added Musl builds to releases [#356].
+- Added `himalaya man` command to generate man page [#419].
 
 ### Changed
 
-* Made commands `read`, `attachments`, `flags`, `copy`, `move`,
+- Made commands `read`, `attachments`, `flags`, `copy`, `move`,
   `delete` accept multiple ids.
-* Flipped arguments `ids` and `folder` for commands `copy` and `move`
+- Flipped arguments `ids` and `folder` for commands `copy` and `move`
   in order the folder not to be considered as an id.
 
 ### Fixed
 
-* Fixed missing folder aliases [#430].
+- Fixed missing folder aliases [#430].
 
 ### Removed
 
-* Removed the `-a|--attachment` argument from `write`, `reply` and
+- Removed the `-a|--attachment` argument from `write`, `reply` and
   `forward` commands. Instead you can attach documents directly from
   the template using the syntax `<#part
   filename=/path/to/you/document.ext>`.
-* Removed the `-e|--encrypt` flag from `write`, `reply` and `forward`
+- Removed the `-e|--encrypt` flag from `write`, `reply` and `forward`
   commands. Instead you can encrypt and sign parts directly from the
   template using the syntax `<#part type=text/plain encrypt=command
   sign=command>Hello!<#/part>`.
-* Removed the `-l|--log-level` option, use instead the `RUST_LOG`
+- Removed the `-l|--log-level` option, use instead the `RUST_LOG`
   environment variable (see the
   [wiki](https://github.com/soywod/himalaya/wiki/Tips:debug-and-logs))
 
@@ -49,434 +73,434 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added `-s|--sanitize` flag for the `read` command.
+- Added `-s|--sanitize` flag for the `read` command.
   
 ### Changed
 
-* Changed the behaviour of the `-t|--mime-type` argument of the `read`
+- Changed the behaviour of the `-t|--mime-type` argument of the `read`
   command. It is less strict now: if no part is found for the given
   MIME type, it will fallback to the other one. For example, giving
   `-t html` will show in priority HTML parts, but if none of them are
   found it will show plain parts instead (and vice versa).
 
-* Sanitization is not done by default when using the `read` command,
+- Sanitization is not done by default when using the `read` command,
   the flag `-s|--sanitize` needs to be explicitly provided.
 
 ### Fixed
 
-* Fixed empty text bodies when reading html part on plain text email
+- Fixed empty text bodies when reading html part on plain text email
   [#352].
 
 ## [0.6.0] - 2022-10-10
 
 ### Changed
 
-* Separated the CLI from the lib module [#340].
+- Separated the CLI from the lib module [#340].
 
   The source code has been splitted into subrepositories:
 
-  * The email logic has been extracted from the CLI and placed in a
+  - The email logic has been extracted from the CLI and placed in a
 	lib on [sourcehut](https://git.sr.ht/~soywod/himalaya-lib)	
-  * The vim plugin is now in a dedicated repository on
+  - The vim plugin is now in a dedicated repository on
     [sourcehut](https://git.sr.ht/~soywod/himalaya-vim) as well
-  * This repository only contains the CLI source code (it was not
+  - This repository only contains the CLI source code (it was not
 	possible to move it to sourcehut because of cross platform builds)
 
-* [**BREAKING**] Renamed `-m|--mailbox` to `-f|--folder`
+- [**BREAKING**] Renamed `-m|--mailbox` to `-f|--folder`
 
-* [**BREAKING**] Refactored config system [#344].
+- [**BREAKING**] Refactored config system [#344].
 
   The configuration has been rethought in order to be more intuitive
   and structured. Here are the breaking changes for the global config:
 
-  * `name` becomes `display-name` and is not mandatory anymore
-  * `signature-delimiter` becomes `signature-delim`
-  * `default-page-size` has been moved to `folder-listing-page-size`
+  - `name` becomes `display-name` and is not mandatory anymore
+  - `signature-delimiter` becomes `signature-delim`
+  - `default-page-size` has been moved to `folder-listing-page-size`
     and `email-listing-page-size`
-  * `notify-cmd`, `notify-query` and `watch-cmds` have been removed
+  - `notify-cmd`, `notify-query` and `watch-cmds` have been removed
     from the global config (available in account config only)
-  * `folder-aliases` has been added to the global config (previously
+  - `folder-aliases` has been added to the global config (previously
     known as `mailboxes` from the account config)
-  * `email-reading-headers`, `email-reading-format`,
+  - `email-reading-headers`, `email-reading-format`,
     `email-reading-decrypt-cmd`, `email-writing-encrypt-cmd` and
     `email-hooks` have been added
   
   The account config inherits the same breaking changes from the
   global config, plus:
 
-  * `imap-*` requires `backend = "imap"`
-  * `maildir-*` requires `backend = "maildir"`
-  * `notmuch-*` requires `backend = "notmuch"`
-  * `smtp-*` requires `sender = "smtp"`
-  * `sendmail-*` requires `sender = "sendmail"`
-  * `pgp-encrypt-cmd` becomes `email-writing-encrypt-cmd`
-  * `pgp-decrypt-cmd` becomes `email-reading-decrypt-cmd`
-  * `mailboxes` becomes `folder-aliases`
-  * `hooks` becomes `email-hooks`
-  * `maildir-dir` becomes `maildir-root-dir`
-  * `notmuch-database-dir` becomes `notmuch-db-path`
+  - `imap-*` requires `backend = "imap"`
+  - `maildir-*` requires `backend = "maildir"`
+  - `notmuch-*` requires `backend = "notmuch"`
+  - `smtp-*` requires `sender = "smtp"`
+  - `sendmail-*` requires `sender = "sendmail"`
+  - `pgp-encrypt-cmd` becomes `email-writing-encrypt-cmd`
+  - `pgp-decrypt-cmd` becomes `email-reading-decrypt-cmd`
+  - `mailboxes` becomes `folder-aliases`
+  - `hooks` becomes `email-hooks`
+  - `maildir-dir` becomes `maildir-root-dir`
+  - `notmuch-database-dir` becomes `notmuch-db-path`
 
 ## [0.5.10] - 2022-03-20
 
 ### Fixed
 
-* Flag commands [#334]
-* Windows build [#346]
+- Flag commands [#334]
+- Windows build [#346]
 
 ## [0.5.9] - 2022-03-12
 
 ### Added
 
-* SMTP pre-send hook [#178]
-* Customize headers to show at the top of a read message [#338]
+- SMTP pre-send hook [#178]
+- Customize headers to show at the top of a read message [#338]
 
 ### Changed
 
-* Improve `attachments` command [#281]
+- Improve `attachments` command [#281]
 
 ### Fixed
 
-* `In-Reply-To` not set properly when replying to a message [#323]
-* `Cc` missing or invalid when replying to a message [#324]
-* Notmuch backend hangs [#329]
-* Maildir e2e tests [#335]
-* JSON API for listings [#331]
+- `In-Reply-To` not set properly when replying to a message [#323]
+- `Cc` missing or invalid when replying to a message [#324]
+- Notmuch backend hangs [#329]
+- Maildir e2e tests [#335]
+- JSON API for listings [#331]
 
 ## [0.5.8] - 2022-03-04
 
 ### Added
 
-* Flowed format support [#206]
-* List accounts command [#244]
-* One cargo feature per backend [#318]
+- Flowed format support [#206]
+- List accounts command [#244]
+- One cargo feature per backend [#318]
 
 ### Changed
 
-* Vim doc about mailbox pickers [#298]
+- Vim doc about mailbox pickers [#298]
 
 ### Fixed
 
-* Some emojis break the table layout [#300]
-* Bad sender and date in reply and forward template [#321]
+- Some emojis break the table layout [#300]
+- Bad sender and date in reply and forward template [#321]
 
 ## [0.5.7] - 2022-03-01
 
 ### Added
 
-* Notmuch support [#57]
+- Notmuch support [#57]
 
 ### Fixed
 
-* Build failure due to `imap` version [#303]
-* No tilde expansion in `maildir-dir` [#305]
-* Unknown command SORT [#308]
+- Build failure due to `imap` version [#303]
+- No tilde expansion in `maildir-dir` [#305]
+- Unknown command SORT [#308]
 
 ### Changed
 
-* [**BREAKING**] Replace `inbox-folder`, `sent-folder` and `draft-folder` by a generic hashmap `mailboxes`
-* Display short envelopes id for `maildir` and `notmuch` backends [#309]
+- [**BREAKING**] Replace `inbox-folder`, `sent-folder` and `draft-folder` by a generic hashmap `mailboxes`
+- Display short envelopes id for `maildir` and `notmuch` backends [#309]
 
 ## [0.5.6] - 2022-02-22
 
 ### Added
 
-* Sort command [#34]
-* Maildir support [#43]
+- Sort command [#34]
+- Maildir support [#43]
 
 ### Fixed
 
-* Suffix to downloaded attachments with same name [#204]
+- Suffix to downloaded attachments with same name [#204]
 
 ## [0.5.5] - 2022-02-08
 
 ### Added
 
-* [Contributing guide](https://github.com/soywod/himalaya/blob/master/CONTRIBUTING.md) [#256]
-* Notify query config option [#289]
-* End-to-end encryption [#54]
+- [Contributing guide](https://github.com/soywod/himalaya/blob/master/CONTRIBUTING.md) [#256]
+- Notify query config option [#289]
+- End-to-end encryption [#54]
 
 ### Fixed
 
-* Multiple recipients issue [#288]
-* Cannot parse address [#227]
+- Multiple recipients issue [#288]
+- Cannot parse address [#227]
 
 ## [0.5.4] - 2022-02-05
 
 ### Fixed
 
-* Add attachments with save and send commands [#47] [#259]
-* Invalid sequence set [#276]
+- Add attachments with save and send commands [#47] [#259]
+- Invalid sequence set [#276]
 
 ## [0.5.3] - 2022-02-03
 
 ### Added
 
-* Activate rust-imap logs when trace mode is enabled
-* Set up cargo deployment
+- Activate rust-imap logs when trace mode is enabled
+- Set up cargo deployment
 
 ## [0.5.2] - 2022-02-02
 
 ### Fixed
 
-* Blur in list msg screenshot [#181]
-* Make inbox, sent and drafts folders customizable [#172]
-* Vim plugin get focused msg id [#268]
-* Nix run issue [#272]
-* Range not displayed when fetch fails [#276]
-* Blank lines and spaces in `text/plain` parts [#280]
-* Watch command [#271]
-* Mailbox telescope.nvim preview [#249]
+- Blur in list msg screenshot [#181]
+- Make inbox, sent and drafts folders customizable [#172]
+- Vim plugin get focused msg id [#268]
+- Nix run issue [#272]
+- Range not displayed when fetch fails [#276]
+- Blank lines and spaces in `text/plain` parts [#280]
+- Watch command [#271]
+- Mailbox telescope.nvim preview [#249]
 
 ### Removed
 
-* The wiki git submodule [#273]
+- The wiki git submodule [#273]
 
 ## [0.5.1] - 2021-10-24
 
 ### Added
 
-* Disable color feature [#185]
-* `--max-width|-w` argument to restrict listing table width [#220]
+- Disable color feature [#185]
+- `--max-width|-w` argument to restrict listing table width [#220]
 
 ### Fixed
 
-* Error when receiving notification from `notify` command [#228]
+- Error when receiving notification from `notify` command [#228]
 
 ### Changed
 
-* Remove error when empty subject [#229]
-* Vim plugin does not render anymore the msg by itself, it uses the one available from the CLI [#220]
+- Remove error when empty subject [#229]
+- Vim plugin does not render anymore the msg by itself, it uses the one available from the CLI [#220]
 
 ## [0.5.0] - 2021-10-10
 
 ### Added
 
-* Mailto support [#162]
-* Remove previous signature when replying/forwarding a message [#193]
-* Config option `signature-delimiter` to customize the signature delimiter (default to `-- \n`) [[#114](https://github.com/soywod/himalaya/pull/114)]
-* Expand tilde and env vars for `downloads-dir` and `signature` [#102]
+- Mailto support [#162]
+- Remove previous signature when replying/forwarding a message [#193]
+- Config option `signature-delimiter` to customize the signature delimiter (default to `-- \n`) [[#114](https://github.com/soywod/himalaya/pull/114)]
+- Expand tilde and env vars for `downloads-dir` and `signature` [#102]
 
 ### Changed
 
-* [**BREAKING**] Folder structure, message management, JSON API and Vim plugin [#199]
-* Pagination for list and search cmd starts from 1 instead of 0 [#186]
-* Errors management with `anyhow` [#152]
+- [**BREAKING**] Folder structure, message management, JSON API and Vim plugin [#199]
+- Pagination for list and search cmd starts from 1 instead of 0 [#186]
+- Errors management with `anyhow` [#152]
 
 ### Fixed
 
-* Panic on flags command [#190]
-* Make more use of serde [#153]
-* Write message vim plugin [#196]
-* Invalid encoding when sending message [#205]
-* Pagination reset current account [#215]
-* New/reply/forward from Vim plugin since Tpl refactor [#176]
+- Panic on flags command [#190]
+- Make more use of serde [#153]
+- Write message vim plugin [#196]
+- Invalid encoding when sending message [#205]
+- Pagination reset current account [#215]
+- New/reply/forward from Vim plugin since Tpl refactor [#176]
 
 ## [0.4.0] - 2021-06-03
 
 ### Added
 
-* Add ability to change account in with the Vim plugin [#91]
-* Add possibility to make Himalaya default email app [#160] [[#161](https://github.com/soywod/himalaya/pull/161)]
+- Add ability to change account in with the Vim plugin [#91]
+- Add possibility to make Himalaya default email app [#160] [[#161](https://github.com/soywod/himalaya/pull/161)]
 
 ### Changed
 
-* [**BREAKING**] Short version of reply `--all` arg is now `-A` to
+- [**BREAKING**] Short version of reply `--all` arg is now `-A` to
   avoid conflicts with `--attachment|-a`
-* Template management [#80]
+- Template management [#80]
 
 ### Fixed
 
-* `\Seen` flag when moving a message
-* Attachments arg for reply and forward commands [#109]
-* Vim doc [#117]
+- `\Seen` flag when moving a message
+- Attachments arg for reply and forward commands [#109]
+- Vim doc [#117]
 
 ### Removed
 
-* `Content-Type` from templates [#146]
+- `Content-Type` from templates [#146]
 
 ## [0.3.2] - 2021-05-08
 
 ### Added
 
-* Mailbox attributes [#134]
-* Wiki entry about new messages counter [#121]
-* Copy/move/delete a message in vim [#95]
+- Mailbox attributes [#134]
+- Wiki entry about new messages counter [#121]
+- Copy/move/delete a message in vim [#95]
 
 ### Changed
 
-* Get signature from file [#135]
-* [**BREAKING**] Split `idle` command into two commands:
-  * `notify`: Runs `notify-cmd` when a new message arrives to the server
-  * `watch`: Runs `watch-cmds` when any change occurs on the server
+- Get signature from file [#135]
+- [**BREAKING**] Split `idle` command into two commands:
+  - `notify`: Runs `notify-cmd` when a new message arrives to the server
+  - `watch`: Runs `watch-cmds` when any change occurs on the server
 
 ### Removed
 
-* `.exe` extension from release binaries [#144]
+- `.exe` extension from release binaries [#144]
 
 ## [0.3.1] - 2021-05-04
 
 ### Added
 
-* Send message via stdin [#78]
+- Send message via stdin [#78]
 
 ### Fixed
 
-* Table with subject containing `\r`, `\n` or `\t` [#141]
-* Overflow panic when shrink column [#138]
-* Vim plugin empty mailbox message [#136]
+- Table with subject containing `\r`, `\n` or `\t` [#141]
+- Overflow panic when shrink column [#138]
+- Vim plugin empty mailbox message [#136]
 
 ## [0.3.0] - 2021-04-28
 
 ### Fixed
 
-* IDLE mode after network interruption [#123]
-* Output redirected to `stderr` [#130]
-* Refactor table system [#132]
-* Editon file format on Linux [#133]
-* Show email address when name not available [#131]
+- IDLE mode after network interruption [#123]
+- Output redirected to `stderr` [#130]
+- Refactor table system [#132]
+- Editon file format on Linux [#133]
+- Show email address when name not available [#131]
 
 ### Removed
 
-* `--log-level|-l` arg (replaced by default `RUST_LOG` env var from `env_logger`) [#130]
+- `--log-level|-l` arg (replaced by default `RUST_LOG` env var from `env_logger`) [#130]
 
 ## [0.2.7] - 2021-04-24
 
 ### Added
 
-* Default page size to config [#96]
-* Custom config path [#86]
-* Setting idle-hook-cmds
+- Default page size to config [#96]
+- Custom config path [#86]
+- Setting idle-hook-cmds
 
 ### Changed
 
-* Plain logger with `env_logger` [#126]
-* Refresh email list on load buffer [#125]
+- Plain logger with `env_logger` [#126]
+- Refresh email list on load buffer [#125]
 
 ### Fixed
 
-* Improve config compatibility on Windows [[#111](https://github.com/soywod/himalaya/pull/111)]
-* Vim table containing emoji [#122]
+- Improve config compatibility on Windows [[#111](https://github.com/soywod/himalaya/pull/111)]
+- Vim table containing emoji [#122]
 
 ## [0.2.6] - 2021-04-17
 
 ### Added
 
-* Insecure TLS option [#84] [#103](https://github.com/soywod/himalaya/pull/103) [[#105](https://github.com/soywod/himalaya/pull/105)]
-* Completion subcommands [[#99](https://github.com/soywod/himalaya/pull/99)]
-* Vim flags to enable telescope preview and to choose picker [[#97](https://github.com/soywod/himalaya/pull/97)]
+- Insecure TLS option [#84] [#103](https://github.com/soywod/himalaya/pull/103) [[#105](https://github.com/soywod/himalaya/pull/105)]
+- Completion subcommands [[#99](https://github.com/soywod/himalaya/pull/99)]
+- Vim flags to enable telescope preview and to choose picker [[#97](https://github.com/soywod/himalaya/pull/97)]
 
 ### Changed
 
-* Make `install.sh` POSIX compliant [[#53](https://github.com/soywod/himalaya/pull/53)]
+- Make `install.sh` POSIX compliant [[#53](https://github.com/soywod/himalaya/pull/53)]
 
 ### Fixed
 
-* SMTP port [#87]
-* Save msg upon error [#59]
-* Answered flag not set [#50]
-* Panic when downloads-dir does not exist [#100]
-* Idle mode incorrect new message notification [#48]
+- SMTP port [#87]
+- Save msg upon error [#59]
+- Answered flag not set [#50]
+- Panic when downloads-dir does not exist [#100]
+- Idle mode incorrect new message notification [#48]
 
 ## [0.2.5] - 2021-04-12
 
 ### Fixed
 
-* Expunge mbox after `move` and `delete` cmd [#83]
-* JSON output [#89]
+- Expunge mbox after `move` and `delete` cmd [#83]
+- JSON output [#89]
 
 ## [0.2.4] - 2021-04-09
 
 ### Added
 
-* Wiki entry for Gmail users [#58]
-* Info logs for copy/move/delete cmd + silent mode [#74]
-* `--raw` arg for `read` cmd [#79]
+- Wiki entry for Gmail users [#58]
+- Info logs for copy/move/delete cmd + silent mode [#74]
+- `--raw` arg for `read` cmd [#79]
 
 ### Changed
 
-* Refactor output system + log levels [#74]
+- Refactor output system + log levels [#74]
 
 ## [0.2.3] - 2021-04-08
 
 ### Added
 
-* Telescope support [#61]
+- Telescope support [#61]
 
 ### Fixed
 
-* Unicode chars breaks the view [#71]
-* Copy/move incomplete (missing parts) [#75]
+- Unicode chars breaks the view [#71]
+- Copy/move incomplete (missing parts) [#75]
 
 ## [0.2.2] - 2021-04-04
 
 ### Added
 
-* `w` alias for `write` cmd
+- `w` alias for `write` cmd
 
 ### Fixed
 
-* `attachments` cmd logs
-* Page size arg `search` cmd
+- `attachments` cmd logs
+- Page size arg `search` cmd
 
 ## [0.2.1] - 2021-04-04
 
 ### Added
 
-* IDLE support [#29]
-* Improve choice after editing msg [#30]
-* Flags management [#41]
-* Copy feature [#35]
-* Move feature [#31]
-* Delete feature [#36]
-* Signature support [#33]
-* Add attachment(s) to a message (CLI) [#37]
+- IDLE support [#29]
+- Improve choice after editing msg [#30]
+- Flags management [#41]
+- Copy feature [#35]
+- Move feature [#31]
+- Delete feature [#36]
+- Signature support [#33]
+- Add attachment(s) to a message (CLI) [#37]
 
 ### Changed
 
-* Errors management with `error_chain` [#39]
+- Errors management with `error_chain` [#39]
 
 ### Fixed
 
-* Missing `FLAGS` column in messages table [#40]
-* Subtract with overflow if next page empty [#38]
+- Missing `FLAGS` column in messages table [#40]
+- Subtract with overflow if next page empty [#38]
 
 ## [0.2.0] - 2021-03-10
 
 ### Added
 
-* STARTTLS support [#32]
-* Flags [#25]
+- STARTTLS support [#32]
+- Flags [#25]
 
 ### Changed
 
-* JSON support [#18]
+- JSON support [#18]
 
 ## [0.1.0] - 2021-01-17
 
 ### Added
 
-* Parse TOML config [#1]
-* Populate Config struct from TOML [#2]
-* Set up IMAP connection [#3]
-* List new emails [#6]
-* Set up CLI arg parser [#15]
-* List mailboxes command [#5]
-* Text and HTML previews [#12] [#13]
-* Set up SMTP connection [#4]
-* Write new email [#8]
-* Write new email [#8]
-* Reply, reply all and forward [#9] [#10] [#11]
-* Download attachments [#14]
-* Merge `Email` with `Msg` [#21]
-* List command with pagination [#19]
-* Icon in table when attachment is present [#16]
-* Multi-account [#17]
-* Password from command [#22]
-* Set up README [#20]
+- Parse TOML config [#1]
+- Populate Config struct from TOML [#2]
+- Set up IMAP connection [#3]
+- List new emails [#6]
+- Set up CLI arg parser [#15]
+- List mailboxes command [#5]
+- Text and HTML previews [#12] [#13]
+- Set up SMTP connection [#4]
+- Write new email [#8]
+- Write new email [#8]
+- Reply, reply all and forward [#9] [#10] [#11]
+- Download attachments [#14]
+- Merge `Email` with `Msg` [#21]
+- List command with pagination [#19]
+- Icon in table when attachment is present [#16]
+- Multi-account [#17]
+- Password from command [#22]
+- Set up README [#20]
 
-[Unreleased]: https://github.com/soywod/himalaya/compare/v0.7.0...HEAD
-[0.7.0]: https://github.com/soywod/himalaya/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/soywod/himalaya/compare/v0.6.1...v0.6.2
+[Unreleased]: https://github.com/soywod/himalaya/compare/v0.7.1...develop
+[0.7.1]: https://github.com/soywod/himalaya/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/soywod/himalaya/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/soywod/himalaya/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/soywod/himalaya/compare/v0.5.10...v0.6.0
 [0.5.10]: https://github.com/soywod/himalaya/compare/v0.5.9...v0.5.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,6 @@ email at
 
 If you want to **discuss** about the project, feel free to join the
 [Matrix](https://matrix.org/) workspace
-[#pimalaya](https://matrix.to/#/#pimalaya:matrix.org) or contact me
-directly [@soywod](https://matrix.to/#/@soywod:matrix.org).
+[#pimalaya.himalaya](https://matrix.to/#/#pimalaya.himalaya:matrix.org)
+or contact me directly
+[@soywod](https://matrix.to/#/@soywod:matrix.org).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "himalaya"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "himalaya-lib"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96448bba297a565c27dc18404da17d465e79df2feffa632b249281c8c0b5b68"
+checksum = "d6aa84cdd1cec7bd25e319f0decd7d6ec5d765fb983da7a0dea10d797f7e73a8"
 dependencies = [
  "ammonia",
  "chrono",
@@ -1124,6 +1124,7 @@ checksum = "5d2d08d52a925272eda99f8fe9e91237b1cb958804ee0628cc398ebd1bbc426f"
 dependencies = [
  "gethostname",
  "mailparse",
+ "memmap2",
 ]
 
 [[package]]
@@ -1189,6 +1190,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "himalaya"
 description = "Command-line interface for email management."
-version = "0.7.0"
+version = "0.7.1"
 authors = ["soywod <clement.douin@posteo.net>"]
 edition = "2021"
 license = "MIT"
@@ -17,9 +17,9 @@ section = "mail"
 
 [features]
 imap-backend = ["himalaya-lib/imap-backend"]
-maildir-backend = ["himalaya-lib/maildir-backend"]
+smtp-sender = ["himalaya-lib/smtp-sender"]
 notmuch-backend = ["himalaya-lib/notmuch-backend"]
-default = ["imap-backend", "maildir-backend"]
+default = ["imap-backend", "smtp-sender"]
 
 [dev-dependencies]
 tempfile = "3.3"
@@ -36,7 +36,7 @@ dialoguer = "0.10.2"
 email_address = "0.2.4"
 env_logger = "0.8"
 erased-serde = "0.3"
-himalaya-lib = "0.5"
+himalaya-lib = "0.6.0"
 indicatif = "0.17"
 log = "0.4"
 once_cell = "1.16.0"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,43 @@
-# 📫 Himalaya [![GitHub release](https://img.shields.io/github/v/release/soywod/himalaya?color=success&style=flat-square)](https://github.com/soywod/himalaya/releases/latest) [![Matrix](https://img.shields.io/matrix/himalaya.email.client:matrix.org?color=success&label=chat&style=flat-square)](https://matrix.to/#/#himalaya.email.client:matrix.org)
+# 📫 Himalaya [![GitHub release](https://img.shields.io/github/v/release/soywod/himalaya?color=success)](https://github.com/soywod/himalaya/releases/latest) [![Matrix](https://img.shields.io/matrix/pimalaya.himalaya:matrix.org?color=success&label=chat)](https://matrix.to/#/#pimalaya.himalaya:matrix.org)
 
-Command-line interface for email management based on the
-[himalaya-lib](https://git.sr.ht/~soywod/himalaya-lib).
+Himalaya is a CLI based on the
+[himalaya-lib](https://git.sr.ht/~soywod/himalaya-lib) that allows you
+to manipulate your emails using commands in your console.
 
 ![image](https://user-images.githubusercontent.com/10437171/138774902-7b9de5a3-93eb-44b0-8cfb-6d2e11e3b1aa.png)
 
-*Warning: the project is under active development, do not use in
+*Disclaimer: the project is under active development, do not use in
 production before the `v1.0.0`.*
 
 ## Features
 
-- Folder listing
-- Email listing and searching
-- Email composition based on `$EDITOR`
-- Email manipulation (copy/move/delete)
-- Multi-accounting
-- Account listing
+- [Folder listing]
+- [Envelopes listing], [searching] and [sorting]
+- [Email composition] based on `$EDITOR`
+- Email manipulation ([copy]/[move]/[delete])
+- [Multi-accounting]
+- [Account listing]
+- [Account synchronization] for offline usage
 - IMAP, Maildir and Notmuch support
-- IMAP IDLE mode for real-time notifications
+- IMAP IDLE mode for [real-time notifications]
 - PGP end-to-end encryption
-- Completions for various shells
+- [Completions] for various shells
 - JSON output
 - …
 
-*Note: see the [wiki](https://github.com/soywod/himalaya/wiki) for all
-the features.*
+[Folder listing]: https://pimalaya.org/himalaya/docs/cli/usage/folders/list.html
+[Envelopes listing]: https://pimalaya.org/himalaya/docs/cli/usage/envelopes/list.html
+[searching]: https://pimalaya.org/himalaya/docs/cli/usage/envelopes/search.html
+[sorting]: https://pimalaya.org/himalaya/docs/cli/usage/envelopes/sort.html
+[Email composition]: https://pimalaya.org/himalaya/docs/cli/usage/emails/write.html
+[copy]: https://pimalaya.org/himalaya/docs/cli/usage/emails/copy.html
+[move]: https://pimalaya.org/himalaya/docs/cli/usage/emails/move.html
+[delete]: https://pimalaya.org/himalaya/docs/cli/usage/emails/delete.html
+[Multi-accounting]: https://pimalaya.org/himalaya/docs/cli/configuration.html
+[Account listing]: https://pimalaya.org/himalaya/docs/cli/usage/accounts/list.html
+[Account synchronization]: https://pimalaya.org/himalaya/docs/cli/usage/accounts/synchronize.html
+[real-time notifications]: https://pimalaya.org/himalaya/docs/cli/usage/notifications.html
+[Completions]: https://pimalaya.org/himalaya/docs/cli/tips/completion.html
 
 ## Installation
 
@@ -37,7 +50,7 @@ the features.*
 </td>
 <td width="50%">
 
-```shell
+```bash
 # Arch Linux (official)
 $ pacman -S himalaya
 
@@ -54,9 +67,9 @@ $ cargo install himalaya
 $ nix-env -i himalaya
 ```
 
-*Note: see the
-[wiki](https://github.com/soywod/himalaya/wiki/Installation) for other
-installation methods.*
+*See the
+[documentation](https://pimalaya.org/himalaya/docs/cli/installation.html)
+for other installation methods.*
 
 </td>
 </tr>
@@ -64,49 +77,8 @@ installation methods.*
 
 ## Configuration
 
-```toml
-# ~/.config/himalaya/config.toml
-
-display-name = "Test"
-downloads-dir = "~/downloads"
-signature = "Regards,"
-
-[gmail]
-default = true
-email = "test@gmail.com"
-
-backend = "imap"
-imap-host = "imap.gmail.com"
-imap-port = 993
-imap-login = "test@gmail.com"
-imap-passwd-cmd = "security find-internet-password -gs gmail -w"
-
-sender = "smtp"
-smtp-host = "smtp.gmail.com"
-smtp-port = 465
-smtp-login = "test@gmail.com"
-smtp-passwd-cmd = "security find-internet-password -gs gmail -w"
-
-[gmail.folder-aliases]
-inbox = "INBOX"
-sent = "[Gmail]/Sent"
-drafts = "[Gmail]/Drafts"
-
-[local]
-email = "test@localhost"
-signature-delim = "~~\n"
-signature = "Regards,"
-
-backend = "maildir"
-maildir-root-dir = "~/emails"
-
-sender = "sendmail"
-sendmail-cmd = "msmtp --read-envelope-from --read-recipients"
-```
-
-*Note: see the
-[wiki](https://github.com/soywod/himalaya/wiki/Configuration) for all
-the options.*
+Please read the
+[documentation](https://pimalaya.org/himalaya/docs/cli/configuration.html).
 
 ## Contributing
 
@@ -132,7 +104,7 @@ email at
 
 If you want to **discuss** about the project, feel free to join the
 [Matrix](https://matrix.org/) workspace
-[#pimalaya](https://matrix.to/#/#pimalaya:matrix.org) or contact me
+[#pimalaya.himalaya](https://matrix.to/#/#pimalaya.himalaya:matrix.org) or contact me
 directly [@soywod](https://matrix.to/#/@soywod:matrix.org).
 
 ## Credits
@@ -163,8 +135,8 @@ European Commission in September, 2022.
 
 ## Sponsoring
 
-[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors&style=flat-square)](https://github.com/sponsors/soywod)
-[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff&style=flat-square)](https://www.paypal.com/paypalme/soywod)
-[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff&style=flat-square)](https://ko-fi.com/soywod)
-[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000&style=flat-square)](https://www.buymeacoffee.com/soywod)
-[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222&style=flat-square)](https://liberapay.com/soywod)
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -31,14 +31,22 @@ pub struct DeserializedConfig {
 
     pub email_listing_page_size: Option<usize>,
     pub email_reading_headers: Option<Vec<String>>,
-    #[serde(default, with = "EmailTextPlainFormatOptionDef", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        with = "EmailTextPlainFormatOptionDef",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub email_reading_format: Option<EmailTextPlainFormat>,
     pub email_reading_verify_cmd: Option<String>,
     pub email_reading_decrypt_cmd: Option<String>,
     pub email_writing_headers: Option<Vec<String>>,
     pub email_writing_sign_cmd: Option<String>,
     pub email_writing_encrypt_cmd: Option<String>,
-    #[serde(default, with = "EmailHooksOptionDef", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        with = "EmailHooksOptionDef",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub email_hooks: Option<EmailHooks>,
 
     #[serde(flatten)]
@@ -115,12 +123,10 @@ impl DeserializedConfig {
 
 #[cfg(test)]
 mod tests {
-    use himalaya_lib::{EmailSender, SendmailConfig, SmtpConfig};
+    use himalaya_lib::{EmailSender, MaildirConfig, SendmailConfig, SmtpConfig};
 
     #[cfg(feature = "imap-backend")]
     use himalaya_lib::ImapConfig;
-    #[cfg(feature = "maildir-backend")]
-    use himalaya_lib::MaildirConfig;
     #[cfg(feature = "notmuch-backend")]
     use himalaya_lib::NotmuchConfig;
 
@@ -131,7 +137,6 @@ mod tests {
 
     #[cfg(feature = "imap-backend")]
     use crate::account::DeserializedImapAccountConfig;
-    #[cfg(feature = "maildir-backend")]
     use crate::account::DeserializedMaildirAccountConfig;
     #[cfg(feature = "notmuch-backend")]
     use crate::account::DeserializedNotmuchAccountConfig;

--- a/src/config/prelude.rs
+++ b/src/config/prelude.rs
@@ -1,12 +1,12 @@
-use himalaya_lib::{EmailHooks, EmailSender, EmailTextPlainFormat, SendmailConfig, SmtpConfig};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+use himalaya_lib::{
+    EmailHooks, EmailSender, EmailTextPlainFormat, MaildirConfig, SendmailConfig, SmtpConfig,
+};
+
 #[cfg(feature = "imap-backend")]
 use himalaya_lib::ImapConfig;
-
-#[cfg(feature = "maildir-backend")]
-use himalaya_lib::MaildirConfig;
 
 #[cfg(feature = "notmuch-backend")]
 use himalaya_lib::NotmuchConfig;
@@ -56,7 +56,6 @@ pub struct ImapConfigDef {
     pub watch_cmds: Option<Vec<String>>,
 }
 
-#[cfg(feature = "maildir-backend")]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(remote = "MaildirConfig")]
 pub struct MaildirConfigDef {

--- a/src/config/wizard/maildir.rs
+++ b/src/config/wizard/maildir.rs
@@ -7,7 +7,6 @@ use dialoguer::Input;
 use dirs::home_dir;
 use himalaya_lib::MaildirConfig;
 
-#[cfg(feature = "maildir-backend")]
 pub(crate) fn configure(base: DeserializedBaseAccountConfig) -> Result<DeserializedAccountConfig> {
     let input = if let Some(home) = home_dir() {
         Input::with_theme(&*THEME)

--- a/src/config/wizard/mod.rs
+++ b/src/config/wizard/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "imap-backend")]
 mod imap;
-#[cfg(feature = "maildir-backend")]
 mod maildir;
 #[cfg(feature = "notmuch-backend")]
 mod notmuch;
@@ -18,10 +17,9 @@ use once_cell::sync::Lazy;
 use std::{fs, process};
 
 const BACKENDS: &[&str] = &[
+    "Maildir",
     #[cfg(feature = "imap-backend")]
     "IMAP",
-    #[cfg(feature = "maildir-backend")]
-    "Maildir",
     #[cfg(feature = "notmuch-backend")]
     "Notmuch",
 ];
@@ -102,10 +100,9 @@ pub(crate) fn wizard() -> Result<DeserializedConfig> {
 
     match default {
         Some(DeserializedAccountConfig::None(default)) => default.default = Some(true),
+        Some(DeserializedAccountConfig::Maildir(default)) => default.base.default = Some(true),
         #[cfg(feature = "imap-backend")]
         Some(DeserializedAccountConfig::Imap(default)) => default.base.default = Some(true),
-        #[cfg(feature = "maildir-backend")]
-        Some(DeserializedAccountConfig::Maildir(default)) => default.base.default = Some(true),
         #[cfg(feature = "notmuch-backend")]
         Some(DeserializedAccountConfig::Notmuch(default)) => default.base.default = Some(true),
         _ => {}
@@ -141,10 +138,9 @@ fn configure_account() -> Result<Option<DeserializedAccountConfig>> {
         .interact_opt()?;
 
     match backend {
+        Some(idx) if BACKENDS[idx] == "Maildir" => Ok(Some(maildir::configure(base)?)),
         #[cfg(feature = "imap-backend")]
         Some(idx) if BACKENDS[idx] == "IMAP" => Ok(Some(imap::configure(base)?)),
-        #[cfg(feature = "maildir-backend")]
-        Some(idx) if BACKENDS[idx] == "Maildir" => Ok(Some(maildir::configure(base)?)),
         #[cfg(feature = "notmuch-backend")]
         Some(idx) if BACKENDS[idx] == "Notmuch" => Ok(Some(notmuch::configure(base)?)),
         _ => Ok(None),

--- a/src/domain/account/accounts.rs
+++ b/src/domain/account/accounts.rs
@@ -40,13 +40,12 @@ impl From<Iter<'_, String, DeserializedAccountConfig>> for Accounts {
     fn from(map: Iter<'_, String, DeserializedAccountConfig>) -> Self {
         let mut accounts: Vec<_> = map
             .map(|(name, account)| match account {
+                DeserializedAccountConfig::Maildir(config) => {
+                    Account::new(name, "maildir", config.base.default.unwrap_or_default())
+                }
                 #[cfg(feature = "imap-backend")]
                 DeserializedAccountConfig::Imap(config) => {
                     Account::new(name, "imap", config.base.default.unwrap_or_default())
-                }
-                #[cfg(feature = "maildir-backend")]
-                DeserializedAccountConfig::Maildir(config) => {
-                    Account::new(name, "maildir", config.base.default.unwrap_or_default())
                 }
                 #[cfg(feature = "notmuch-backend")]
                 DeserializedAccountConfig::Notmuch(config) => {

--- a/src/domain/account/handlers.rs
+++ b/src/domain/account/handlers.rs
@@ -43,12 +43,16 @@ pub fn sync<P: Printer>(
     account_config: &AccountConfig,
     printer: &mut P,
     backend: &dyn Backend,
+    folder: &Option<String>,
     dry_run: bool,
 ) -> Result<()> {
     info!("entering the sync accounts handler");
     trace!("dry run: {}", dry_run);
 
-    let sync_builder = BackendSyncBuilder::new(account_config);
+    let mut sync_builder = BackendSyncBuilder::new(account_config);
+    if let Some(folder) = folder {
+        sync_builder = sync_builder.only_folder(folder);
+    }
 
     if dry_run {
         let report = sync_builder.dry_run(true).sync(backend)?;

--- a/src/domain/folder/handlers.rs
+++ b/src/domain/folder/handlers.rs
@@ -7,6 +7,15 @@ use himalaya_lib::{AccountConfig, Backend};
 
 use crate::printer::{PrintTableOpts, Printer};
 
+pub fn expunge<P: Printer, B: Backend + ?Sized>(
+    folder: &str,
+    printer: &mut P,
+    backend: &mut B,
+) -> Result<()> {
+    backend.expunge_folder(folder)?;
+    printer.print(format!("Folder {folder} successfully expunged!"))
+}
+
 pub fn list<P: Printer, B: Backend + ?Sized>(
     max_width: Option<usize>,
     config: &AccountConfig,
@@ -122,6 +131,9 @@ mod tests {
                         desc: "desc".into(),
                     },
                 ]))
+            }
+            fn expunge_folder(&self, _: &str) -> backend::Result<()> {
+                unimplemented!();
             }
             fn purge_folder(&self, _: &str) -> backend::Result<()> {
                 unimplemented!();


### PR DESCRIPTION
### Added

- Added command `folders expunge` that deletes all emails marked for
  deletion.
  
### Changed

- Changed the location of the
  [documentation](https://pimalaya.org/himalaya/docs/).

### Fixed

- Fixed broken links in README.md.

### Removed

- Removed the `maildir-backend` cargo feature, it is now included by
  default.
- Removed issues section on GitHub, now issues need to be opened by
  sending an email at
  [~soywod/pimalaya@todo.sr.ht](mailto:~soywod/pimalaya@todo.sr.ht).

## himalaya-lib v0.6.0

### Added

- Added ability to synchronize specific folders only [#37].
- Added `Backend::expunge` function that definitely removes emails
  with the `Deleted` flag.
- Added `Backend::mark_emails_as_deleted` function with a default
  implementation that adds the `Deleted` flag.

### Changed

- Changed the way emails are deleted. `Backend::delete_emails` now
  moves the email to the `Trash` folder (or to the corresponding alias
  from the config file). If the target folder is the `Trash` folder,
  it will instead add the `Deleted` flag. Emails are removed with the
  `Backend::expunge` function.

### Fixed

- Fixed `ImapBackend::list_envelopes` pagination.
- Fixed synchronization issues for emails without `Message-ID` header
  by using the `Date` header instead.
- Fixed maildir backend perfs issues by enabling the `mmap` feature of
  the `maildir` crate.
  
### Removed

- Removed the `maildir-backend` cargo feature, it is now included by
  default.
