### PR TITLE
Fix editor launch without an attached TTY

### DIFF
--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -6,8 +6,8 @@ use email::{
     sender::Sender,
 };
 use log::debug;
+use std::process::Command;
 use mml::MmlCompilerBuilder;
-use process::Cmd;
 use std::{env, fs};
 
 use crate::{
@@ -23,10 +23,12 @@ pub async fn open_with_tpl(tpl: String) -> Result<String> {
 
     debug!("open editor");
     let editor = env::var("EDITOR").context("cannot get editor from env var")?;
-    Cmd::from(format!("{editor} {}", &path.to_string_lossy()))
-        .run()
-        .await
-        .context("cannot launch editor")?;
+    let child = Command::new(&editor)
+        .arg(&path)
+        .spawn()
+        .context(format!("cannot launch editor {}", &editor))?;
+
+    child.wait().context("Error waiting for editor to close")?;
 
     debug!("read draft");
     let content =


### PR DESCRIPTION
An issue was identified where editors like `vim`, `vi`, or `nvim` might not display correctly when invoked from the program, likely due to the absence of an attached TTY.

Changes:
- Transitioned from `run` to `spawn` for improved control over the launched process.
- Implemented the `wait` method on the spawned process to ensure the editor session completes before continuing.

Before: 
![image](https://github.com/soywod/himalaya/assets/87614587/18e40146-f5e0-4746-a824-986b35d88c37)

After:
![image](https://github.com/soywod/himalaya/assets/87614587/c3414934-0299-4716-b952-b454a9803b90)

