### PR TITLE
allow account.sendmail when sendmail feature is on

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -113,6 +113,7 @@ impl From<Iter<'_, String, TomlAccountConfig>> for Accounts {
                     backends.push_str("smtp");
                 }
 
+                #[cfg(feature = "sendmail")]
                 if account.sendmail.is_some() {
                     if !backends.is_empty() {
                         backends.push_str(", ")


### PR DESCRIPTION
when default features are turned off and the `sendmail` feature isn't enabled, it doesn't build. this fixes that.