### PR TITLE
fix ambiguous email export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,4 @@ pub mod smtp;
 pub mod ui;
 
 #[doc(inline)]
-// pub use email::{envelope, flag, message, template};
-pub use email::{envelope, flag, message};
+pub use crate::email::{envelope, flag, message};


### PR DESCRIPTION
i'm working on updating the nixos module definitions for himalaya to be able to build the most recent 1.0.0-beta. when building with the next version of rust about to be available in nixpkgs (1.70.0), this ambiguous export was found and preventing building. the version of rust used in this repo's nix environment allows the build to proceed. locally, i updated the `flake.nix` to more closely emulate the build environment of nixpkgs. i can commit that as well in this PR if desired.