### PR TITLE
fix: honor positional input in save commands

### DIFF
--- a/src/email/message/command/save.rs
+++ b/src/email/message/command/save.rs
@@ -61,7 +61,7 @@ impl MessageSaveCommand {
 
         let is_tty = io::stdin().is_terminal();
         let is_json = printer.is_json();
-        let msg = if is_tty || is_json {
+        let msg = if !self.message.raw.is_empty() || is_tty || is_json {
             self.message.raw()
         } else {
             io::stdin()

--- a/src/email/message/template/command/save.rs
+++ b/src/email/message/template/command/save.rs
@@ -67,7 +67,7 @@ impl TemplateSaveCommand {
 
         let is_tty = io::stdin().is_terminal();
         let is_json = printer.is_json();
-        let tpl = if is_tty || is_json {
+        let tpl = if !self.template.raw.is_empty() || is_tty || is_json {
             self.template.raw()
         } else {
             io::stdin()
@@ -85,8 +85,6 @@ impl TemplateSaveCommand {
         compiler.set_some_pgp(account_config.pgp.clone());
 
         let msg = compiler.build(tpl.as_str())?.compile().await?.into_vec()?;
-
-        backend.add_message(folder, &msg).await?;
 
         let id = backend.add_message(folder, &msg).await?;
 


### PR DESCRIPTION
Closes #645

  This fixes non-interactive positional input handling for draft save commands.

  Changes:
  - `message save` now uses the positional message when it is provided, even when stdin is not a TTY
  - `template save` now uses the positional template when it is provided, even when stdin is not a TTY
  - `template save` no longer appends the same draft twice

  Repro before:
  - `message save ... $'Subject: ...\r\n\r\nBody'` sent `APPEND Drafts {0}`
  - `template save ... $'From: ...\n\nBody'` failed with `cannot parse template`

  Verified with patched binary against IMAP proxy:
  - `message save` now sends a non-empty append (`APPEND Drafts {71}` in my repro)
  - `template save` now sends a non-empty append (`APPEND Drafts {347}` in my repro)