### PR TITLE
bump rust to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.90"
 profile = "default"
 components = ["rust-src", "rust-analyzer"]


### PR DESCRIPTION
Rustup defaults to an old version without this fix. Thanks!